### PR TITLE
Fixes #15 - use CASCADE for dropping views

### DIFF
--- a/django_pgviews/view.py
+++ b/django_pgviews/view.py
@@ -107,14 +107,14 @@ def create_view(connection, view_name, view_query, update=True, force=False,
                 cursor.execute('DROP VIEW IF EXISTS check_conflict;')
 
         if materialized:
-            cursor.execute('DROP MATERIALIZED VIEW IF EXISTS {0};'.format(view_name))
+            cursor.execute('DROP MATERIALIZED VIEW IF EXISTS {0} CASCADE;'.format(view_name))
             cursor.execute('CREATE MATERIALIZED VIEW {0} AS {1};'.format(view_name, view_query))
             ret = view_exists and 'UPDATED' or 'CREATED'
         elif not force_required:
             cursor.execute('CREATE OR REPLACE VIEW {0} AS {1};'.format(view_name, view_query))
             ret = view_exists and 'UPDATED' or 'CREATED'
         elif force:
-            cursor.execute('DROP VIEW IF EXISTS {0};'.format(view_name))
+            cursor.execute('DROP VIEW IF EXISTS {0} CASCADE;'.format(view_name))
             cursor.execute('CREATE VIEW {0} AS {1};'.format(view_name, view_query))
             ret = 'FORCED'
         else:
@@ -133,9 +133,9 @@ def clear_view(connection, view_name, materialized=False):
     cursor = cursor_wrapper.cursor
     try:
         if materialized:
-            cursor.execute('DROP MATERIALIZED VIEW IF EXISTS {0}'.format(view_name))
+            cursor.execute('DROP MATERIALIZED VIEW IF EXISTS {0} CASCADE'.format(view_name))
         else:
-            cursor.execute('DROP VIEW IF EXISTS {0}'.format(view_name))
+            cursor.execute('DROP VIEW IF EXISTS {0} CASCADE'.format(view_name))
     finally:
         cursor_wrapper.close()
     return u'DROPPED'.format(view=view_name)

--- a/tests/test_project/test_project/viewtest/models.py
+++ b/tests/test_project/test_project/viewtest/models.py
@@ -11,7 +11,6 @@ class TestModel(models.Model):
 
 class Superusers(django_pgviews.View):
     projection = ['auth.User.*']
-    dependencies = ('viewtest.RelatedView',)
     sql = """SELECT * FROM auth_user WHERE is_superuser = TRUE;"""
 
 
@@ -36,6 +35,16 @@ class RelatedView(django_pgviews.ReadOnlyView):
 class MaterializedRelatedView(django_pgviews.ReadOnlyMaterializedView):
     sql = """SELECT id AS model_id, id FROM viewtest_testmodel"""
     model = models.ForeignKey(TestModel)
+
+
+class DependantView(django_pgviews.ReadOnlyView):
+    dependencies = ('viewtest.RelatedView',)
+    sql = """SELECT model_id from viewtest_relatedview;"""
+
+
+class DependantMaterializedView(django_pgviews.ReadOnlyMaterializedView):
+    dependencies = ('viewtest.MaterializedRelatedView',)
+    sql = """SELECT model_id from viewtest_materializedrelatedview;"""
 
 
 class CustomSchemaView(django_pgviews.ReadOnlyView):


### PR DESCRIPTION
the simplest solution for fixing #15 that I could think of is using `CASCADE` when dropping views. Since the sync command is taking care of syncing the views in the right order, it's not a problem to use `DROP VIEW CASCADE` since child views that were dropped by that will be always synced again afterwards.
The dependency problem was also there for the `clear_pgviews` command, that's why I had to use `CASCADE` there as well.

The only problem I can think of for this solution is the following: if you have views in your DB which are not managed by `django-pgviews` but depend on another view which IS managed by `django-pgviews`, then it might be dropped during `sync_pgviews` and will definitely be dropped during `clear_pgviews`. I'm not sure if this is an edge case we should try to handle. I'd be happy to hear opinions on that.