### PR TITLE
Support for concurrent refresh via unique index in materialized views

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,36 @@ def customer_saved(sender, action=None, instance=None, **kwargs):
     PreferredCustomer.refresh()
 ```
 
+Postgres 9.4 and up allow materialized views to be refreshed concurrently, without blocking reads, as long as a
+unique index exists on the materialized view. To enable concurrent refresh, specify the name of a column that can be
+used as a unique index on the materialized view. Once enabled, passing `concurrently=True` to the model's refresh
+method will result in postgres performing the refresh concurrently. (Note that the refresh method itself blocks until
+the refresh is complete; concurrent refresh is most useful when materialized views are updated in
+another process or thread.)
+
+Example:
+
+```python
+from django_pgviews import view as pg
+
+
+VIEW_SQL = """
+    SELECT id, name, post_code FROM myapp_customer WHERE is_preferred = TRUE
+"""
+
+class PreferredCustomer(pg.MaterializedView):
+    concurrent_index = 'id'
+    sql = VIEW_SQL
+
+    name = models.CharField(max_length=100)
+    post_code = models.CharField(max_length=20)
+
+
+@receiver(post_save, sender=Customer)
+def customer_saved(sender, action=None, instance=None, **kwargs):
+    PreferredCustomer.refresh(concurrently=True)
+```
+
 ### Custom Schema
 
 You can define any table name you wish for your views. They can even live inside your own custom

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ dependencies:
   override:
     - pip install tox tox-pyenv
   post:
-    - pyenv global 2.7.10 3.4.3 3.5.0
+    - pyenv global 2.7.12 3.4.4 3.5.2
   pre:
     - sudo apt-get install python3-dev -y
 notify:

--- a/django_pgviews/models.py
+++ b/django_pgviews/models.py
@@ -49,7 +49,8 @@ class ViewSyncer(object):
             try:
                 status = create_view(connection, view_cls._meta.db_table,
                         view_cls.sql, update=update, force=force,
-                        materialized=isinstance(view_cls(), MaterializedView))
+                        materialized=isinstance(view_cls(), MaterializedView),
+                        index=view_cls._concurrent_index)
                 self.synced.append(name)
             except Exception as exc:
                 exc.view_cls = view_cls

--- a/tests/test_project/test_project/viewtest/models.py
+++ b/tests/test_project/test_project/viewtest/models.py
@@ -46,6 +46,10 @@ class DependantMaterializedView(django_pgviews.ReadOnlyMaterializedView):
     dependencies = ('viewtest.MaterializedRelatedView',)
     sql = """SELECT model_id from viewtest_materializedrelatedview;"""
 
+class MaterializedRelatedViewWithIndex(django_pgviews.ReadOnlyMaterializedView):
+    concurrent_index = 'id'
+    sql = """SELECT id AS model_id, id FROM viewtest_testmodel"""
+    model = models.ForeignKey(TestModel)
 
 class CustomSchemaView(django_pgviews.ReadOnlyView):
     sql = """SELECT id AS model_id, id FROM viewtest_testmodel"""

--- a/tests/test_project/test_project/viewtest/tests.py
+++ b/tests/test_project/test_project/viewtest/tests.py
@@ -35,7 +35,7 @@ class ViewTestCase(TestCase):
                         WHERE matviewname LIKE 'viewtest_%';''')
 
             count, = cur.fetchone()
-            self.assertEqual(count, 2)
+            self.assertEqual(count, 3)
 
             cur.execute('''SELECT COUNT(*) FROM information_schema.views
                         WHERE table_schema = 'test_schema';''')
@@ -112,6 +112,11 @@ class ViewTestCase(TestCase):
 
         self.assertEqual(models.MaterializedRelatedView.objects.count(), 1,
             'Materialized view should have updated')
+
+        models.MaterializedRelatedViewWithIndex.refresh(concurrently=True)
+
+        self.assertEqual(models.MaterializedRelatedViewWithIndex.objects.count(), 1,
+            'Materialized view should have updated concurrently')
 
 
 class DependantViewTestCase(TestCase):


### PR DESCRIPTION
To enable concurrent refresh of a materialized view, add an attribute 'concurrent_index' specifying the name of a column in the materialized view that can serve as a unique index.

For example:
class MyMaterializedView(MaterializedView):
    sql = """SELECT id, other FROM table;"""
    concurrent_index = 'id'

django> MyMaterializedView.refresh(concurrently=True)