### PR TITLE
Signal when views are synced

### DIFF
--- a/django_pgviews/signals.py
+++ b/django_pgviews/signals.py
@@ -1,0 +1,6 @@
+from django.dispatch import Signal
+
+
+view_synced = Signal(
+    providing_args=['update', 'force', 'status', 'has_changed'])
+all_views_synced = Signal()

--- a/tests/test_project/test_project/viewtest/tests.py
+++ b/tests/test_project/test_project/viewtest/tests.py
@@ -120,21 +120,38 @@ class ViewTestCase(TestCase):
             'Materialized view should have updated concurrently')
 
     def test_signals(self):
+        expected = {
+            models.MaterializedRelatedView: {
+                'status': 'CREATED',
+                'has_changed': True,
+            },
+            models.Superusers: {
+                'status': 'EXISTS',
+                'has_changed': False,
+            }
+        }
         synced_views = []
         all_views_were_synced = [False]
 
         @receiver(view_synced)
-        def on_view_synced(sender, has_changed, **kwargs):
+        def on_view_synced(sender, **kwargs):
             synced_views.append(sender)
+            if sender in expected:
+                expected_kwargs = expected.pop(sender)
+                self.assertEqual(
+                    dict(expected_kwargs,
+                         update=False, force=False, signal=view_synced),
+                    kwargs)
 
         @receiver(all_views_synced)
         def on_all_views_synced(sender, **kwargs):
             all_views_were_synced[0] = True
 
-        call_command('sync_pgviews')
+        call_command('sync_pgviews', update=False)
 
         self.assertEqual(len(synced_views), 8)  # All views went through syncing
         self.assertEqual(all_views_were_synced[0], True)
+        self.assertFalse(expected)
 
 
 class DependantViewTestCase(TestCase):


### PR DESCRIPTION
This PR adds 2 signals, `view_synced` and `all_views_synced`, that can be used to add additional actions to the view's creation.

This will enable customising views after they are created, for example by creating custom indexes (like in #26) or changing view's permissions.