### PR TITLE
Use Django Database routing

### DIFF
--- a/django_pgviews/management/commands/clear_pgviews.py
+++ b/django_pgviews/management/commands/clear_pgviews.py
@@ -2,7 +2,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 from django.apps import apps
-from django.db import connection
+from django.db import connections, router
 
 from django_pgviews.view import clear_view, View, MaterializedView
 
@@ -22,6 +22,8 @@ class Command(BaseCommand):
                     hasattr(view_cls, 'sql')):
                 continue
             python_name = '{}.{}'.format(view_cls._meta.app_label, view_cls.__name__)
+            using = router.db_for_write(view_cls)
+            connection = connections[using]
             status = clear_view(
                 connection, view_cls._meta.db_table,
                 materialized=isinstance(view_cls(), MaterializedView))

--- a/django_pgviews/models.py
+++ b/django_pgviews/models.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.apps import apps
-from django.db import connection
+from django.db import connections, router
 
 from django_pgviews.view import create_view, View, MaterializedView
 from django_pgviews.signals import view_synced, all_views_synced
@@ -50,6 +50,8 @@ class ViewSyncer(object):
                 continue # Skip
 
             try:
+                using = router.db_for_write(view_cls)
+                connection = connections[using]
                 status = create_view(connection, view_cls._meta.db_table,
                         view_cls.sql, update=update, force=force,
                         materialized=isinstance(view_cls(), MaterializedView),

--- a/django_pgviews/view.py
+++ b/django_pgviews/view.py
@@ -7,7 +7,7 @@ import re
 
 import django
 from django.core import exceptions
-from django.db import connection
+from django.db import connections, router
 from django.db.models.query import QuerySet
 from django.db import models
 from django.utils import six
@@ -264,6 +264,8 @@ class MaterializedView(View):
     """
     @classmethod
     def refresh(self, concurrently=False):
+        using = router.db_for_write(self.__class__)
+        connection = connections[using]
         cursor_wrapper = connection.cursor()
         cursor = cursor_wrapper.cursor
         try:


### PR DESCRIPTION
In our project we use multiple databases. They are chosen based on Model's app name.

Here's the documentation:
https://docs.djangoproject.com/en/1.11/topics/db/multi-db/#using-routers

This change makes sure routers are taken into account when creating a connection