### PR TITLE
Create views inside an atomic transaction

### DIFF
--- a/django_pgviews/view.py
+++ b/django_pgviews/view.py
@@ -101,10 +101,10 @@ def create_view(connection, view_name, view_query, update=True, force=False,
             # update this copy, and detecting errors.
             cursor.execute('CREATE TEMPORARY VIEW check_conflict AS SELECT * FROM {0};'.format(view_name))
             try:
-                cursor.execute('CREATE OR REPLACE TEMPORARY VIEW check_conflict AS {0};'.format(view_query))
+                with transaction.atomic():
+                    cursor.execute('CREATE OR REPLACE TEMPORARY VIEW check_conflict AS {0};'.format(view_query))
             except psycopg2.ProgrammingError:
                 force_required = True
-                cursor.connection.rollback()
             finally:
                 cursor.execute('DROP VIEW IF EXISTS check_conflict;')
 

--- a/django_pgviews/view.py
+++ b/django_pgviews/view.py
@@ -7,7 +7,7 @@ import re
 
 import django
 from django.core import exceptions
-from django.db import connection
+from django.db import connection, transaction
 from django.db.models.query import QuerySet
 from django.db import models
 from django.utils import six
@@ -64,6 +64,7 @@ def realize_deferred_projections(sender, *args, **kwargs):
 models.signals.class_prepared.connect(realize_deferred_projections)
 
 
+@transaction.atomic()
 def create_view(connection, view_name, view_query, update=True, force=False,
         materialized=False, index=None):
     """


### PR DESCRIPTION
With this change we ensure `DROP` ... `CREATE` happens inside an atomic transaction, and if any issues happens during the `CREATE` process, the "old" view is still accessible.

Also, within the transaction, we understand that the view is accessible even during its creation, being replaced only when the new one is available (after commit).