### PR TITLE
Add optional ability to generate SQL using classmethod

### DIFF
--- a/django_pgviews/apps.py
+++ b/django_pgviews/apps.py
@@ -2,6 +2,7 @@ import logging
 
 from django import apps
 from django.db.models import signals
+from django.conf import settings
 
 log = logging.getLogger('django_pgviews.sync_pgviews')
 
@@ -31,4 +32,5 @@ class ViewConfig(apps.AppConfig):
     def ready(self):
         """Find and setup the apps to set the post_migrate hooks for.
         """
-        signals.post_migrate.connect(self.sync_pgviews)
+        if not getattr(settings, 'PGVIEWS_DISABLE_AUTO_SYNC', False):
+            signals.post_migrate.connect(self.sync_pgviews)

--- a/django_pgviews/models.py
+++ b/django_pgviews/models.py
@@ -50,7 +50,7 @@ class ViewSyncer(object):
                 continue # Skip
 
             try:
-                if has_attr(view_cls, 'generate_sql'):
+                if hasattr(view_cls, 'generate_sql'):
                     view_sql = view_cls.generate_sql()
                 else:
                     view_sql = view_cls.sql

--- a/django_pgviews/models.py
+++ b/django_pgviews/models.py
@@ -50,8 +50,13 @@ class ViewSyncer(object):
                 continue # Skip
 
             try:
+                if has_attr(view_cls, 'generate_sql'):
+                    view_sql = view_cls.generate_sql()
+                else:
+                    view_sql = view_cls.sql
+                
                 status = create_view(connection, view_cls._meta.db_table,
-                        view_cls.sql, update=update, force=force,
+                        view_sql, update=update, force=force,
                         materialized=isinstance(view_cls(), MaterializedView),
                         index=view_cls._concurrent_index)
                 view_synced.send(


### PR DESCRIPTION
I have a use case where I'm joining several models into a unified View, and I'd like for the view to include all of the fields from all of the tables (and to update automagically if any of the models have new columns added).

It's possible for me to generate the columns for my SELECT query using a list comprehensions and a model's <model>._meta.get_fields() method, however, this method fails if the models haven't been loaded into Django yet, so I can't just call .format against my SQL string when defining the View class' sql string.

This changeset allows a view to define a class method `generate_sql` on a view, if that classmethod is present then it is used to get the sql which is used to define the view instead of the class sql property.