### PR TITLE
Add PGVIEWS_SYNCER_CLASS setting

### DIFF
--- a/django_pgviews/apps.py
+++ b/django_pgviews/apps.py
@@ -29,7 +29,7 @@ class ViewConfig(apps.AppConfig):
             vs.run(force=True, update=True)
 
     def get_view_syncer_class(self, default='django_pgviews.models.ViewSyncer'):
-        return import_string(getattr(settings, 'PGVIEWS_SYNCER_CLASS', None) or default)
+        return import_string(getattr(settings, 'PGVIEWS_VIEW_SYNCER_CLASS', None) or default)
 
     def ready(self):
         """Find and setup the apps to set the post_migrate hooks for.

--- a/django_pgviews/apps.py
+++ b/django_pgviews/apps.py
@@ -2,6 +2,8 @@ import logging
 
 from django import apps
 from django.db.models import signals
+from django.utils.module_loading import import_string
+from django.conf import settings
 
 log = logging.getLogger('django_pgviews.sync_pgviews')
 
@@ -19,14 +21,15 @@ class ViewConfig(apps.AppConfig):
         """
         self.counter = self.counter + 1
         total = len([a for a in apps.apps.get_app_configs() if a.models_module is not None])
-        
+
         if self.counter == total:
             log.info('All applications have migrated, time to sync')
-            # Import here otherwise Django doesn't start properly
-            # (models in app init are not allowed)
-            from .models import ViewSyncer
-            vs = ViewSyncer()
-            vs.run(force=True, update=True) 
+            view_syncer_cls = self.get_view_syncer_class()
+            vs = view_syncer_cls()
+            vs.run(force=True, update=True)
+
+    def get_view_syncer_class(self, default='django_pgviews.models.ViewSyncer'):
+        return import_string(getattr(settings, 'PGVIEWS_SYNCER_CLASS', None) or default)
 
     def ready(self):
         """Find and setup the apps to set the post_migrate hooks for.


### PR DESCRIPTION
Add ability to specify a custom view syncer class. A custom view syncer can be used, for example, to define a different strategy to determine which views should be updated